### PR TITLE
Use aliases in tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ Things to note with `EntityOptions`
 - aliases are used to create an alias for a configured entity
 - defaultProperties are also used as default parameters when sending api requests
 
+## Using aliases in TableNodes or PyStringNode
+```php
+    Given an existing "TYPE" created with static method "create" with alias "TYPE1"
+    When I add a new "TYPE" with:
+    """
+      {
+        "clinicId": "%Alias:FieldName%"
+      }
+    """
+```
+If Alias does exist, %Alias:FieldName% is replaced with the FieldName of the Alias entity
+
+You can also reference only the alias, if so, it will use the primary key of the entity.
+
+
 ## License
 Copyright (c) 2016 Interactive Solutions Bodama AB
 

--- a/src/Context/EntityFixtureContext.php
+++ b/src/Context/EntityFixtureContext.php
@@ -249,6 +249,26 @@ class EntityFixtureContext implements SnippetAcceptingContext, ServiceManagerAwa
     }
 
     /**
+     * Add a entity of the given type with the default values created with the entities static method
+     *
+     * @Given an existing :type created with static method :staticMethodName with alias :alias
+     *
+     * @param string $type
+     *
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws TransactionRequiredException
+     *
+     * @return void
+     */
+    public function anExistingTypeCreatedWithStaticMethodAndAlias($type, $staticMethodName, $alias)
+    {
+        $entity = $this->anExistingTypeCreatedWithStaticMethod($type, $staticMethodName);
+
+        $this->aliases[$alias] = $entity;
+    }
+
+    /**
      * Add a entity of the given type and merging the default values with the new ones
      *
      * @Given an existing :type with values:


### PR DESCRIPTION
Allow most of the steps to convert values in  TableNodes or PyStringNodes to a specified field of the alias
Added a step to check if response contains a value, this also supports using aliases
Updated README.md